### PR TITLE
Use the `show_symbol_type_toc` option of `mkdocstrings-python`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ plugins:
             show_root_members_full_path: true
             show_signature_annotations: true
             show_source: true
+            show_symbol_type_toc: true
             signature_crossrefs: true
           import:
             - https://docs.python.org/3/objects.inv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,8 @@ dev-mkdocs = [
   "mkdocs-literate-nav == 0.6.1",
   "mkdocs-macros-plugin == 1.0.5",
   "mkdocs-material == 9.5.20",
-  "mkdocstrings[python] == 0.25.0",
+  "mkdocstrings[python] == 0.25.1",
+  "mkdocstrings-python == 1.9.2",
   "frequenz-repo-config[lib] == 0.9.2",
 ]
 dev-mypy = [


### PR DESCRIPTION
This shows the symbol type in the table of contents of the documentation.
