### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -1,0 +1,15 @@
+name: Auto-approve Dependabot PRs
+
+on:
+  pull_request:
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Auto-approve and merge Dependabot PRs
+        uses: frequenz-floss/dependabot-auto-approve@v1.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: merge


### PR DESCRIPTION
Adds automatic approval and merging of Dependabot PRs using the frequenz-floss/dependabot-auto-approve@v1.3.0 action.