### PR TITLE
Update auto-merge workflow to use hashes

### DIFF
--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -9,7 +9,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Auto-approve and merge Dependabot PRs
-        uses: frequenz-floss/dependabot-auto-approve@v1.3.0
+        uses: frequenz-floss/dependabot-auto-approve@005e52004f5d5c6af2f81b89ec25e5cf6f3dfd77 # v1.3.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           merge-method: merge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev-flake8 = [
   "pydoclint == 0.7.6",
   "pydocstyle == 6.3.0",
 ]
-dev-formatting = ["black == 25.9.0", "isort == 6.1.0"]
+dev-formatting = ["black == 25.9.0", "isort == 7.0.0"]
 dev-mkdocs = [
   "black == 25.9.0",
   "Markdown==3.9",


### PR DESCRIPTION
Use commit hash for `frequenz-floss/dependabot-auto-approve` action for better security and reproducibility.